### PR TITLE
Problem: Various GPIO problems

### DIFF
--- a/include/libgpio.h
+++ b/include/libgpio.h
@@ -38,6 +38,7 @@
 #define GPIO_BUFFER_MAX      4
 #define GPIO_DIRECTION_MAX  64 // 35
 #define GPIO_VALUE_MAX      64 // 30
+#define GPIO_MAX_RETRY       3
 
 
 #ifdef __cplusplus

--- a/install.xml
+++ b/install.xml
@@ -15,6 +15,7 @@ Installation model
     <item path = "/usr/share/fty-sensor-gpio/data/" name = "../src/selftest-ro/data/VIB001.tpl" />
     <item path = "/usr/share/fty-sensor-gpio/data/" name = "../src/selftest-ro/data/WLD012.tpl" />
     <item path = "/usr/share/fty-sensor-gpio/data/" name = "../src/selftest-ro/data/XCELW.tpl" />
+    <item path = "/usr/share/fty-sensor-gpio/data/" name = "../src/selftest-ro/data/GPOTEST.tpl" />
     <item path = "/etc/udev/rules.d/"  name = "../src/42-ity-gpio.rules" />
     <item path = "/lib/udev/"  name = "../src/42ity-gpio-permissions" />
 </install>

--- a/install.xml
+++ b/install.xml
@@ -15,4 +15,6 @@ Installation model
     <item path = "/usr/share/fty-sensor-gpio/data/" name = "../src/selftest-ro/data/VIB001.tpl" />
     <item path = "/usr/share/fty-sensor-gpio/data/" name = "../src/selftest-ro/data/WLD012.tpl" />
     <item path = "/usr/share/fty-sensor-gpio/data/" name = "../src/selftest-ro/data/XCELW.tpl" />
+    <item path = "/etc/udev/rules.d/"  name = "../src/42-ity-gpio.rules" />
+    <item path = "/lib/udev/"  name = "../src/42ity-gpio-permissions" />
 </install>

--- a/src/42-ity-gpio.rules
+++ b/src/42-ity-gpio.rules
@@ -1,0 +1,3 @@
+# udev rules for GPIO access
+
+KERNEL=="gpio*", SUBSYSTEM=="gpio*", ACTION=="add", PROGRAM="/lib/udev/42ity-gpio-permissions %p"

--- a/src/42ity-gpio-permissions
+++ b/src/42ity-gpio-permissions
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+PATH='/sbin:/bin'
+basedir="/sys/class/gpio"
+devpath=$1
+
+chmod -R 770 $basedir
+chown -R :gpio $basedir
+
+if [ "$1" = "enable" ] ; then
+    for f in export unexport ; do
+        chmod g+w $basedir/$f
+        chown :gpio $basedir/$f
+    done
+else
+    for f in active_low direction edge value ; do
+        chmod g+w /sys${devpath}/$f
+        chown :gpio /sys${devpath}/$f
+    done
+fi
+exit 0
+
+SUBSYSTEM=="gpio*", PROGRAM="/bin/sh -c 'chown -R root:gpio /sys/class/gpio && chmod -R 770 /sys/class/gpio; chown -R root:gpio /sys/devices/virtual/gpio && chmod -R 770 /sys/devices/virtual/gpio; chown -R root:gpio /sys/devices/platform/soc/*.gpio/gpio && chmod -R 770 /sys/devices/platform/soc/*.gpio/gpio'"


### PR DESCRIPTION
Problem: Need privileges to access GPIO sysfs

Solution: Add udev rule and script, and code delay.
There must be a minimum delay between exporting the GPIO, which triggers the
creation of new entries under sysfs, and setting the direction and further
operations on the GPIO, for the udev rules to be applied.

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>

Problem: Need a way to test GPO without actual device

Solution: Install the GPOTEST template too

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>