### PR TITLE
Problem: Various cppcheck issues

### DIFF
--- a/src/fty_sensor_gpio_alerts.cc
+++ b/src/fty_sensor_gpio_alerts.cc
@@ -53,12 +53,12 @@ str_replace(char* string, const char* substr, const char* replacement)
 	int   replacement_len = 0;
 
 	newstr = strdup(string);
-	substr_len = strlen(substr);
-	replacement_len = strlen(replacement);
 
 	if (substr == NULL || replacement == NULL) {
 		return newstr;
 	}
+	substr_len = strlen(substr);
+	replacement_len = strlen(replacement);
 
 	while ((tok = strstr(newstr, substr))) {
 		oldstr = newstr;

--- a/src/fty_sensor_gpio_alerts.cc
+++ b/src/fty_sensor_gpio_alerts.cc
@@ -45,42 +45,40 @@ struct _fty_sensor_gpio_alerts_t {
 static char*
 str_replace(char* string, const char* substr, const char* replacement)
 {
-	char* tok = NULL;
-	char* newstr = NULL;
-	char* oldstr = NULL;
-	int   oldstr_len = 0;
-	int   substr_len = 0;
-	int   replacement_len = 0;
+    char* tok = NULL;
+    char* newstr = NULL;
+    int   substr_len = 0;
+    int   replacement_len = 0;
 
-	newstr = strdup(string);
+    newstr = strdup(string);
 
-	if (substr == NULL || replacement == NULL) {
-		return newstr;
-	}
-	substr_len = strlen(substr);
-	replacement_len = strlen(replacement);
+    if (substr == NULL || replacement == NULL) {
+        return newstr;
+    }
+    substr_len = strlen(substr);
+    replacement_len = strlen(replacement);
 
-	while ((tok = strstr(newstr, substr))) {
-		oldstr = newstr;
-		oldstr_len = strlen(oldstr);
-		newstr = (char*)malloc(sizeof(char) * (oldstr_len - substr_len + replacement_len + 1));
+    while ((tok = strstr(newstr, substr))) {
+        char* oldstr = newstr;
+        int   oldstr_len = strlen(oldstr);
+        newstr = (char*)malloc(sizeof(char) * (oldstr_len - substr_len + replacement_len + 1));
 
-		if (newstr == NULL) {
-			free(oldstr);
-			return NULL;
-		}
+        if (newstr == NULL) {
+            free(oldstr);
+            return NULL;
+        }
 
-		memcpy(newstr, oldstr, tok - oldstr);
-		memcpy(newstr + (tok - oldstr), replacement, replacement_len);
-		memcpy(newstr + (tok - oldstr) + replacement_len, tok + substr_len, oldstr_len - substr_len - (tok - oldstr));
-		memset(newstr + oldstr_len - substr_len + replacement_len, 0, 1);
+        memcpy(newstr, oldstr, tok - oldstr);
+        memcpy(newstr + (tok - oldstr), replacement, replacement_len);
+        memcpy(newstr + (tok - oldstr) + replacement_len, tok + substr_len, oldstr_len - substr_len - (tok - oldstr));
+        memset(newstr + oldstr_len - substr_len + replacement_len, 0, 1);
 
-		free(oldstr);
-	}
+        free(oldstr);
+    }
 
-	free(string);
+    free(string);
 
-	return newstr;
+    return newstr;
 }
 
 //  --------------------------------------------------------------------------

--- a/src/fty_sensor_gpio_assets.cc
+++ b/src/fty_sensor_gpio_assets.cc
@@ -739,6 +739,7 @@ fty_sensor_gpio_assets_test (bool verbose)
         assert (sensors_count == 2);
         // Only test the first sensor
         _gpx_info_t *gpx_info = (_gpx_info_t *)zlistx_first (test_gpx_list);
+        assert (gpx_info);
         gpx_info = (_gpx_info_t *)zlistx_next (test_gpx_list);
         assert (gpx_info);
         assert (streq (gpx_info->asset_name, "sensorgpio-10"));


### PR DESCRIPTION
Problem: cppcheck reports warning on nullPointer
Solution: Fix it

Problem: cppcheck reports style on variableScope
Solution: Reduce scope of oldstr and oldstr_len

Problem: cppcheck reports performance on redundantAssignment
Solution: Please cppcheck with another assert()

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>