### PR TITLE
Problem : [BIOS-3823] fty-sensor-gpio service dependency to fty-info …

### DIFF
--- a/src/fty-sensor-gpio.service.in
+++ b/src/fty-sensor-gpio.service.in
@@ -1,8 +1,7 @@
 [Unit]
 Description=fty-sensor-gpio service
-Requires=network.target malamute.service
-After=network.target malamute.service
-Before=fty-asset.service
+Requires=network.target malamute.service fty-asset.service
+After=network.target malamute.service fty-asset.service
 PartOf=bios.target
 
 [Service]


### PR DESCRIPTION
…is wrong

Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>