### PR TITLE
Problem: Stopping agent can take up to 90 seconds

### DIFF
--- a/src/fty-sensor-gpio.service.in
+++ b/src/fty-sensor-gpio.service.in
@@ -19,6 +19,7 @@ EnvironmentFile=-@sysconfdir@/default/fty__%n.conf
 Environment="prefix=@prefix@"
 Environment='SYSTEMD_UNIT_FULLNAME=%n'
 ExecStart=@prefix@/bin/fty-sensor-gpio -c @sysconfdir@/@PACKAGE@/fty-sensor-gpio.cfg
+ExecStop=/bin/kill -15 $MAINPID
 Restart=always
 
 [Install]


### PR DESCRIPTION
Solution: Add an ExecStop and sigkill the process
This issue is related to fty-sensor-gpio initialization status: when starting,
it queries the asset agent to get the list of GPIO sensors to monitor.
If the asset agent doesn't respond (either it's busy or stopped), the gpio agent
is blocked with some sort of network timeout, during up to 90 seconds!
While it should not happen in production context, we may want to fix the systemd
unit for fty-sensor-gpio to SIGKILL it upon ExecStop... Since this agent doesn't
persist data, there is no issue. But a failed state is visible with systemd.

For potential later improvements:
Better than sending a SIGKILL, we can add a timeout to the initial asset
request, to not block more than 10 seconds for example. Optionally, we may also
retry later to send the initial asset request (can't hurt, dedup are handled).
This would avoid the "failed state" as visible above, but that's perfectionism!

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>