### PR TITLE
Problem: Stopping agent can take up to 90 seconds

### DIFF
--- a/src/fty-sensor-gpio.service.in
+++ b/src/fty-sensor-gpio.service.in
@@ -19,7 +19,7 @@ EnvironmentFile=-@sysconfdir@/default/fty__%n.conf
 Environment="prefix=@prefix@"
 Environment='SYSTEMD_UNIT_FULLNAME=%n'
 ExecStart=@prefix@/bin/fty-sensor-gpio -c @sysconfdir@/@PACKAGE@/fty-sensor-gpio.cfg
-ExecStop=/bin/kill -9 $MAINPID
+ExecStop=/bin/kill -KILL $MAINPID
 Restart=always
 
 [Install]

--- a/src/fty-sensor-gpio.service.in
+++ b/src/fty-sensor-gpio.service.in
@@ -19,7 +19,7 @@ EnvironmentFile=-@sysconfdir@/default/fty__%n.conf
 Environment="prefix=@prefix@"
 Environment='SYSTEMD_UNIT_FULLNAME=%n'
 ExecStart=@prefix@/bin/fty-sensor-gpio -c @sysconfdir@/@PACKAGE@/fty-sensor-gpio.cfg
-ExecStop=/bin/kill -15 $MAINPID
+ExecStop=/bin/kill -9 $MAINPID
 Restart=always
 
 [Install]


### PR DESCRIPTION
Solution: Use the right SIG KILL (name not number)
The previous commit was still using the SIG TERM, while it should have used KILL

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>