### PR TITLE
Problem: Agent is not restarted after fty-asset

### DIFF
--- a/src/fty-sensor-gpio.service.in
+++ b/src/fty-sensor-gpio.service.in
@@ -23,4 +23,4 @@ ExecStop=/bin/kill -KILL $MAINPID
 Restart=always
 
 [Install]
-WantedBy=bios.target
+WantedBy=bios.target fty-asset.service


### PR DESCRIPTION
Solution: Add a WantedBy=fty-asset.service
The Requires and After "fty-asset.service" allows to express the dependency on
fty-asset.service. This means that stopping fty-asset will also stop
fty-sensor-gpio. However, to automatically restart fty-sensor-gpio when
fty-asset is (re)started, the WantedBy field is required

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>