### PR TITLE
Problem: Agent does not consider Logical Asset field

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ The following fields and extended attributes are available:
 * name (mandatory)
 * type (mandatory): set to 'device'
 * sub_type (mandatory): set to 'sensor-gpio'
-* location (optional): refer to the logical asset to which the sensor is
-connected. It can be for example a rack, a room, or any other asset
+* parent_name.1 (optional): refer to the IPC to which the sensor is connected.
 * status (optional): is the standard status 'active' or 'inactive'
 * priority (optional): is the standard priority, from 'P1' to 'P5'
 * model (mandatory): is the part number of the GPIO sensor, use for naming
@@ -82,7 +81,7 @@ present field to indicate which GPO number is used to power a GPI.
 Example of entries:
 
 ```bash
-name,type,sub_type,location,status,priority,model,port,normal_state,logical_asset,gpo_powersource
+name,type,sub_type,parent_name.1,status,priority,model,port,normal_state,logical_asset,gpo_powersource
 GPIO-Sensor-Door1,device,sensorgpio,IPC1,active,P1,DCS001,1,opened,Rack1,
 GPIO-Sensor-Smoke1,device,sensorgpio,IPC1,active,P1,DCS001,1,opened,Room1,1
 GPIO-Beacon1,device,sensorgpio,IPC1,active,P1,GPOGEN,2,,Room1,
@@ -90,12 +89,13 @@ GPIO-Beacon1,device,sensorgpio,IPC1,active,P1,GPOGEN,2,,Room1,
 
 In the above example, we have:
 
-* One door contact sensor, 'GPIO-Sensor-Door1', connected to the first GPI, and
-located on the door of 'Rack1',
-* One smoke detection sensor, 'GPIO-Sensor-Smoke1', connected to the second GPI,
-powered by the first GPO (gpo_powersource = 1), and located in 'Room1',
-* One beacon, 'GPIO-Beacon1', connected to the second GPO, and located in
-'Room1'.
+* One door contact sensor, 'GPIO-Sensor-Door1', connected to the first GPI of
+the IPC, and located on the door of 'Rack1',
+* One smoke detection sensor, 'GPIO-Sensor-Smoke1', connected to the second GPI
+of the IPC, powered by the first GPO (gpo_powersource = 1), and located in
+'Room1',
+* One beacon, 'GPIO-Beacon1', connected to the second GPO of the IPC, and
+located in 'Room1'.
 
 ## Architecture
 

--- a/include/fty_sensor_gpio.h
+++ b/include/fty_sensor_gpio.h
@@ -49,7 +49,8 @@ typedef struct _gpx_info_s {
     char* ext_name;       // sensor name
     char* part_number;    // GPI sensor part number
     char* type;           // GPI sensor type (door-contact, ...)
-    char* location;       // Parent name, to which the GPIO is attached
+    char* parent;         // Parent name, i.e. IPC, to which the GPIO is attached (parent_name.1)
+    char* location;       // Location, i.e. Room/Row/Rack/..., where the GPIO is deployed (logical_asset)
     int normal_state;     // opened | closed
     int current_state;    // opened | closed
     int gpx_number;       // GPIO number

--- a/include/fty_sensor_gpio_assets.h
+++ b/include/fty_sensor_gpio_assets.h
@@ -49,9 +49,9 @@ FTY_SENSOR_GPIO_EXPORT int
     const char* manufacturer, const char* assetname, const char* extname,
     const char* asset_subtype, const char* sensor_type,
     const char* sensor_normal_state, const char* sensor_gpx_number,
-    const char* sensor_gpx_direction, const char* sensor_location,
-    const char* sensor_power_source, const char* sensor_alarm_message,
-    const char* sensor_alarm_severity);
+    const char* sensor_gpx_direction, const char* sensor_parent,
+    const char* sensor_location, const char* sensor_power_source,
+    const char* sensor_alarm_message, const char* sensor_alarm_severity);
 
 FTY_SENSOR_GPIO_EXPORT void
     request_sensor_power_source(fty_sensor_gpio_assets_t *self, const char* asset_name);

--- a/src/fty_sensor_gpio.cc
+++ b/src/fty_sensor_gpio.cc
@@ -30,6 +30,8 @@
 
 // TODO:
 // * Smart update of existing entries
+// * Add zuuid to GPO_INTERACTION too
+// * Ensure we don't return OK/ERROR
 // * Reenable tests for -server
 // * Location of "data" directory into a variable like other components
 //   (even if a hardcode for starters); use configure-script data preferably

--- a/src/fty_sensor_gpio_alerts.cc
+++ b/src/fty_sensor_gpio_alerts.cc
@@ -107,7 +107,7 @@ publish_alert (fty_sensor_gpio_alerts_t *self, _gpx_info_t *sensor, int ttl, con
                                   sensor->location);
     }
 
-    std::string rule = string(sensor->type) + ".state_change@" + sensor->asset_name;
+    std::string rule = string(sensor->type) + ".state_change@" + sensor->location; //sensor->asset_name;
 
     my_zsys_debug (self->verbose, "%s: publishing alert %s with description:\n%s", __func__, rule.c_str (), description);
     zmsg_t *message = fty_proto_encode_alert(
@@ -115,7 +115,7 @@ publish_alert (fty_sensor_gpio_alerts_t *self, _gpx_info_t *sensor, int ttl, con
         time (NULL),        // timestamp
         ttl,
         rule.c_str (),      // rule
-        sensor->asset_name, // element
+        sensor->location,   // element
         state,              // state
         severity,           // severity
         description,        // description
@@ -359,7 +359,7 @@ fty_sensor_gpio_alerts_test (bool verbose)
             "Eaton", "sensorgpio-10", "GPIO-Sensor-Door1",
             "DCS001", "door-contact-sensor",
             "closed", "1",
-            "GPI", "Rack1", "",
+            "GPI", "IPC1", "Rack1", "",
             "Door has been $status", "WARNING");
 
         assert (rv == 0);
@@ -385,7 +385,7 @@ fty_sensor_gpio_alerts_test (bool verbose)
         assert (recv);
         fty_proto_t *frecv = fty_proto_decode (&recv);
         assert (frecv);
-        assert (streq (fty_proto_name (frecv), "sensorgpio-10"));
+        assert (streq (fty_proto_name (frecv), "Rack1"));
         assert (streq (fty_proto_state (frecv), "ACTIVE"));
         assert (streq (fty_proto_severity (frecv), "WARNING"));
         assert (streq (fty_proto_description (frecv), "Door has been opened"));

--- a/src/fty_sensor_gpio_server.cc
+++ b/src/fty_sensor_gpio_server.cc
@@ -176,12 +176,12 @@ void publish_status (fty_sensor_gpio_server_t *self, _gpx_info_t *sensor, int tt
             time (NULL),
             ttl,
             msg_type.c_str (),
-            sensor->asset_name, //sensor->location,
+            sensor->parent, // sensor->asset_name
             libgpio_get_status_string(sensor->current_state).c_str(),
             "");
         zhash_destroy (&aux);
         if (msg) {
-            std::string topic = msg_type + string("@") + sensor->asset_name; //sensor->location;
+            std::string topic = msg_type + string("@") + sensor->parent;
 //        "status." + port() + "@" + _location;
 
             my_zsys_debug(self->verbose, "\tPort: %s, type: %s, status: %s",
@@ -417,6 +417,7 @@ s_handle_mailbox(fty_sensor_gpio_server_t* self, zmsg_t *message)
             // Check for a parameter, to send (a) specific template(s)
             if (asset_partnumber) {
                 while (asset_partnumber) {
+                    my_zsys_debug (self->verbose, "Asset filter provided: %s", asset_partnumber);
                     // FIXME: use @datadir@ (how?)!
                     string template_filename = string(self->template_dir) + string(asset_partnumber) + string(".tpl");
 
@@ -861,7 +862,7 @@ fty_sensor_gpio_server_test (bool verbose)
         "Eaton", "sensorgpio-10", "GPIO-Sensor-Door1",
         "DCS001", "door-contact-sensor",
         "closed", "1",
-        "GPI", "Rack1", "",
+        "GPI", "IPC1", "Rack1", "",
         "Door has been $status", "WARNING");
     assert (rv == 0);
 
@@ -869,7 +870,7 @@ fty_sensor_gpio_server_test (bool verbose)
         "Eaton", "sensorgpio-11", "GPIO-Test-GPO1",
         "DCS001", "dummy",
         "closed", "1",
-        "GPO", "Room1", "",
+        "GPO", "IPC1", "Room1", "",
         "Dummy has been $status", "WARNING");
     assert (rv == 0);
 


### PR DESCRIPTION
Solution: Use parent_name.1 and logical_asset
Also update the test code, and documentation, along with published metrics and
alerts

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>