### PR TITLE
Problem: fty-asset wanting gpio is redundant

### DIFF
--- a/src/fty-sensor-gpio.service.in
+++ b/src/fty-sensor-gpio.service.in
@@ -25,4 +25,4 @@ SuccessExitStatus=SIGKILL SIGTERM 143
 Restart=always
 
 [Install]
-WantedBy=bios.target fty-asset.service
+WantedBy=bios.target


### PR DESCRIPTION
Solution: Per analysis and experiments detailed in comments to https://github.com/42ity/fty-sensor-gpio/pull/31 this fishy dependency has no effect. To match our common pattern and not raise too many questions when issues occur, it can be safely removed.

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>