### PR TITLE
Problem: Agent fty-sensor-gpio will need a state file.

### DIFF
--- a/src/fty-sensor-gpio.conf
+++ b/src/fty-sensor-gpio.conf
@@ -1,2 +1,4 @@
-# create runtime directories for fty-sensor-gpio
+# create template and runtime directories for fty-sensor-gpio
 d /usr/share/fty-sensor-gpio/data 0775 bios root
+d /var/lib/fty/fty-sensor-gpio/ 0775 bios root
+x /var/lib/fty/fty-sensor-gpio/*

--- a/src/fty_sensor_gpio.cc
+++ b/src/fty_sensor_gpio.cc
@@ -72,6 +72,7 @@ int main (int argc, char *argv [])
 {
     char *config_file = NULL;
     zconfig_t *config = NULL;
+    const char *state_file = NULL;
     char* actor_name = NULL;
     char* endpoint = NULL;
     const char* str_poll_interval = NULL;
@@ -136,6 +137,8 @@ int main (int argc, char *argv [])
         if (streq (zconfig_get (config, "server/verbose", "false"), "true")) {
             verbose = true;
         }
+        // State file
+        state_file = s_get (config, "server/statefile", "/var/lib/fty/fty-sensor-gpio/state");
         // Polling interval
         str_poll_interval = s_get (config, "server/check_interval", "2000");
         if (str_poll_interval) {


### PR DESCRIPTION
Solution: Prepare runtime directory and config item for it.

Signed-off-by: Jana Rapava <janarapava@eaton.com>