### PR TITLE
Problem: Agent fty-sensor-gpio needs a state file.

### DIFF
--- a/src/fty-sensor-gpio.conf
+++ b/src/fty-sensor-gpio.conf
@@ -1,2 +1,4 @@
-# create runtime directories for fty-sensor-gpio
+# create template and runtime directories for fty-sensor-gpio
 d /usr/share/fty-sensor-gpio/data 0775 bios root
+d /var/lib/fty/fty-sensor-gpio/ 0775 bios root
+x /var/lib/fty/fty-sensor-gpio/*

--- a/src/fty_sensor_gpio.cc
+++ b/src/fty_sensor_gpio.cc
@@ -72,6 +72,7 @@ int main (int argc, char *argv [])
 {
     char *config_file = NULL;
     zconfig_t *config = NULL;
+    const char *state_file = NULL;
     char* actor_name = NULL;
     char* endpoint = NULL;
     const char* str_poll_interval = NULL;
@@ -136,6 +137,8 @@ int main (int argc, char *argv [])
         if (streq (zconfig_get (config, "server/verbose", "false"), "true")) {
             verbose = true;
         }
+        // State file
+        state_file = s_get (config, "server/statefile", "/var/lib/fty/fty-sensor-gpio/state");
         // Polling interval
         str_poll_interval = s_get (config, "server/check_interval", "2000");
         if (str_poll_interval) {
@@ -289,6 +292,7 @@ int main (int argc, char *argv [])
     for (i = 0; i < gpo_mapping_count; ++i) {
         zstr_sendx (server, "GPO_MAPPING", gpo_mapping[0][i], gpo_mapping[1][i], NULL);
     }
+    zstr_sendx (server, "STATEFILE", state_file, NULL);
 
     // Setup an update event message every x microseconds, to check GPI status
     zloop_t *gpio_status_update = zloop_new();

--- a/src/libgpio.cc
+++ b/src/libgpio.cc
@@ -64,7 +64,7 @@ void *dup_int_ptr (const void *ptr)
     return (void *)new_ptr;
 }
 
-void free_fn (void ** self_ptr)
+static void free_fn (void ** self_ptr)
 {
     if (!self_ptr || !*self_ptr) {
         zsys_error ("Attempt to free NULL");


### PR DESCRIPTION
Solution: Implement a zhashx cache containing <asset_name, {gpo_number, default_state, last_action}>.
On exit, store the cache into file.
On ASSET message, check whether the asset is GPO and update cache accordingly.
On GPO_INTERACTION command, update the last action.
On start, load the cache from the state file.

Signed-off-by: Jana Rapava <janarapava@eaton.com>