### PR TITLE
Problem: Agent segfaults on non-existent statefile

### DIFF
--- a/include/fty_sensor_gpio.h
+++ b/include/fty_sensor_gpio.h
@@ -35,6 +35,7 @@ using namespace std;
 //  Add your own public definitions here, if you need them
 #define FTY_SENSOR_GPIO_AGENT "fty-sensor-gpio"
 #define DEFAULT_POLL_INTERVAL 2000
+#define DEFAULT_STATEFILE_PATH "/var/lib/fty/fty-sensor-gpio/state"
 
 // TODO: get from config
 #define TIMEOUT_MS -1   //wait infinitely

--- a/src/fty-sensor-gpio.cfg.in
+++ b/src/fty-sensor-gpio.cfg.in
@@ -1,11 +1,12 @@
 #   fty-sensor-gpio configuration
 
 server
-    check_interval = 10000       #   Interval between sensors state check, msec
+    check_interval = 10000      #   Interval between sensors state check, msec
     timeout = 10000             #   Client connection timeout, msec
     background = 0              #   Run as background process
     workdir = .                 #   Working directory for daemon
     verbose = 0                 #   Do verbose logging of activity?
+    statefile = /var/lib/fty/fty-sensor-gpio/state
 
 malamute
     endpoint = ipc://@/malamute #   Malamute endpoint

--- a/src/fty_sensor_gpio.cc
+++ b/src/fty_sensor_gpio.cc
@@ -72,7 +72,7 @@ int main (int argc, char *argv [])
 {
     char *config_file = NULL;
     zconfig_t *config = NULL;
-    const char *state_file = NULL;
+    char *state_file = NULL;
     char* actor_name = NULL;
     char* endpoint = NULL;
     const char* str_poll_interval = NULL;
@@ -138,7 +138,7 @@ int main (int argc, char *argv [])
             verbose = true;
         }
         // State file
-        state_file = s_get (config, "server/statefile", "/var/lib/fty/fty-sensor-gpio/state");
+        state_file = strdup(s_get (config, "server/statefile", DEFAULT_STATEFILE_PATH));
         // Polling interval
         str_poll_interval = s_get (config, "server/check_interval", "2000");
         if (str_poll_interval) {
@@ -219,6 +219,9 @@ int main (int argc, char *argv [])
 
     if (endpoint == NULL)
         endpoint = strdup("ipc://@/malamute");
+
+    if (state_file == NULL)
+        state_file = strdup(DEFAULT_STATEFILE_PATH);
 
     // Guess the template installation directory
     char *template_dir = NULL;
@@ -306,6 +309,7 @@ int main (int argc, char *argv [])
     zstr_free(&template_dir);
     zstr_free(&actor_name);
     zstr_free(&endpoint);
+    zstr_free(&state_file);
     zconfig_destroy (&config);
     free(gpi_mapping[0]);
     free(gpi_mapping[1]);

--- a/src/fty_sensor_gpio_server.cc
+++ b/src/fty_sensor_gpio_server.cc
@@ -772,6 +772,10 @@ s_load_state_file (fty_sensor_gpio_server_t *self, const char *state_file)
     int gpo_number;
     int default_state;
     int last_action;
+
+    if (!f_state)
+        return;
+
     while (fscanf (f_state, "%s %d %d %d", asset_name, &gpo_number, &default_state, &last_action) != EOF) {
         // existing GPO entry came from fty-sensor-gpio-assets, which takes precendence
         gpo_state_t *state = (gpo_state_t *) zhashx_lookup (self->gpo_states, (void *)asset_name);


### PR DESCRIPTION
Solution: Only load statefile when it exists
Also improve the default value setting, and add a default value in the
configuration file

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>