### PR TITLE
Problem: Port mappings for GPIs and GPOs are rewriting each other.

### DIFF
--- a/include/libgpio.h
+++ b/include/libgpio.h
@@ -103,9 +103,14 @@ FTY_SENSOR_GPIO_EXPORT void
     libgpio_set_gpo_count (libgpio_t *self, int gpo_count);
 
 //  @interface
-// Add mapping GPx number -> HW pin number
+// Add mapping GPI number -> HW pin number
 FTY_SENSOR_GPIO_EXPORT void
-    libgpio_add_gpio_mapping (libgpio_t *self, int port_num, int pin_num);
+    libgpio_add_gpi_mapping (libgpio_t *self, int port_num, int pin_num);
+
+//  @interface
+// Add mapping GPO number -> HW pin number
+FTY_SENSOR_GPIO_EXPORT void
+    libgpio_add_gpo_mapping (libgpio_t *self, int port_num, int pin_num);
 
 //  @interface
 //  Set the test mode

--- a/src/fty_sensor_gpio.cc
+++ b/src/fty_sensor_gpio.cc
@@ -30,20 +30,13 @@
 
 // TODO:
 // * Smart update of existing entries
-// * Add zuuid to GPO_INTERACTION too
 // * Ensure we don't return OK/ERROR
-// * Reenable tests for -server
 // * Location of "data" directory into a variable like other components
 //   (even if a hardcode for starters); use configure-script data preferably
 // * Documentation
 // ** actors as per https://github.com/zeromq/czmq/blob/master/src/zconfig.c#L15
 // * MAILBOX REQ handling:
 // * cleanup, final cppcheck, fix all FIXMEs...
-// * Support for fine grained pin mapping in config file
-//   gpo_mapping
-//       <gpo number> = <pin number>
-//   gpi_mapping
-//       <gpi number> = <pin number>
 // To be discussed:
 // * Check for convergence with other dry-contacts (on EMP001 and fty-sensor-env, EMP002,
 // * Add 'int last_state' to '_gpx_info_t' and only publish state change?

--- a/src/fty_sensor_gpio_server.cc
+++ b/src/fty_sensor_gpio_server.cc
@@ -788,7 +788,7 @@ s_load_state_file (fty_sensor_gpio_server_t *self, const char *state_file)
                 int rv = libgpio_write (self->gpio_lib, state->gpo_number, state->default_state);
                 if (rv) {
                     zsys_error ("Error during default action %s on GPO #%d",
-                                default_state,
+                                libgpio_get_status_string (default_state).c_str (),
                                 state->gpo_number);
                     state->last_action = GPIO_STATE_UNKNOWN;
                 }
@@ -947,7 +947,7 @@ fty_sensor_gpio_server (zsock_t *pipe, void *args)
                     int port_num = (int) strtol (port_str.c_str (), NULL, 10);
                     int pin_num = (int) strtol (value, NULL, 10);
                     my_zsys_debug (self->verbose, "port_num = %d->pin_num = %d", port_num, pin_num);
-                    libgpio_add_gpio_mapping (self->gpio_lib, port_num, pin_num);
+                    libgpio_add_gpi_mapping (self->gpio_lib, port_num, pin_num);
                     zstr_free (&value);
                 }
                 else if (streq (cmd, "GPO_MAPPING")) {
@@ -959,7 +959,7 @@ fty_sensor_gpio_server (zsock_t *pipe, void *args)
                     int port_num = (int) strtol (port_str.c_str (), NULL, 10);
                     int pin_num = (int) strtol (value, NULL, 10);
                     my_zsys_debug (self->verbose, "port_num = %d->pin_num = %d", port_num, pin_num);
-                    libgpio_add_gpio_mapping (self->gpio_lib, port_num, pin_num);
+                    libgpio_add_gpo_mapping (self->gpio_lib, port_num, pin_num);
                     zstr_free (&value);
                 }
                 else if (streq (cmd, "STATEFILE")) {


### PR DESCRIPTION
Solution: Split them into two caches.

Signed-off-by: Jana Rapava <janarapava@eaton.com>