### PR TITLE
Problem: After initializing GPO, gpx_info->currrent_state may be GPIO…

### DIFF
--- a/src/fty_sensor_gpio_server.cc
+++ b/src/fty_sensor_gpio_server.cc
@@ -292,6 +292,13 @@ s_check_gpio_status(fty_sensor_gpio_server_t *self)
                 }
             }
 
+            // get the correct GPO status if applicable
+            gpo_state_t *state = (gpo_state_t *) zhashx_lookup (self->gpo_states, (void *) gpx_info->asset_name);
+            if ((state && (gpx_info->current_state == GPIO_STATE_UNKNOWN))) {
+                gpx_info->current_state = state->last_action;
+                zsys_debug ("changed GPO state from GPIO_STATE_UNKNOWN to %s", libgpio_get_status_string (gpx_info->current_state).c_str ());
+            }
+
             // Get the current sensor status, only for GPIs, or when no status
             // have been set to GPOs. Otherwise, that reinit GPOs!
             if ( (gpx_info->gpx_direction != GPIO_DIRECTION_OUT)


### PR DESCRIPTION
…_STATE_UNKNOWN even though it's not true.

Solution: Update current_state from GPO state cache when necessary.

Signed-off-by: Jana Rapava <janarapava@eaton.com>