### PR TITLE
[DO NOT MERGE YET] Problem: PIR motion detector normal state is wrong

### DIFF
--- a/src/selftest-ro/data/VIB001.tpl
+++ b/src/selftest-ro/data/VIB001.tpl
@@ -1,7 +1,7 @@
 manufacturer   = Eaton
 part-number    = VIB001
 type           = vibration-sensor
-normal-state   = opened
+normal-state   = closed
 gpx-direction  = GPI
 power-source   = internal
 alarm-severity = WARNING

--- a/src/selftest-ro/data/XCELW.tpl
+++ b/src/selftest-ro/data/XCELW.tpl
@@ -1,7 +1,7 @@
 manufacturer   = Eaton
 part-number    = XCELW
 type           = pir-motion-detector
-normal-state   = opened
+normal-state   = closed
 gpx-direction  = GPI
 power-source   = external
 alarm-severity = WARNING


### PR DESCRIPTION
Solution: Fix it

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>