### PR TITLE
Increase CI timeouts to 30 min

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,7 +150,8 @@ before_install:
 - if [ "$TRAVIS_OS_NAME" == "osx" -a "$BUILD_TYPE" == "valgrind" ] ; then brew install valgrind ; fi
 
 # Hand off to generated script for each BUILD_TYPE
-script: ./ci_build.sh
+# Note: timeout bumped up
+script: travis_wait 30 ./ci_build.sh
 before_deploy: . ./ci_deploy.sh && ./ci_deploy_obs.sh
 deploy:
   provider: releases

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,7 +109,7 @@ pipeline {
             description: 'The clang-format program (v5+) to use for this build, e.g. clang-format-5.0; an empty value means configure-time guesswork',
             name: 'CLANG_FORMAT')
         string (
-            defaultValue: "10",
+            defaultValue: "30",
             description: 'When running tests, use this timeout (in minutes; be sure to leave enough for double-job of a distcheck too)',
             name: 'USE_TEST_TIMEOUT')
         booleanParam (

--- a/project.xml
+++ b/project.xml
@@ -14,6 +14,7 @@
     <target name = "jenkins" >
         <option name = "agent_label" value = "devel-image &amp;&amp; x86_64" />
         <option name = "triggers_pollSCM" value = "H/2 * * * *" />
+        <option name = "use_test_timeout" value = "30" />
         <option name = "test_cppcheck" value = "1" />
         <option name = "build_docs" value = "1" />
         <option name = "dist_docs" value = "1" />


### PR DESCRIPTION
Waiting on (imaginary) ports can take a while