### PR TITLE
Problem: Need to support Zettler MZXE fire sensor

### DIFF
--- a/src/selftest-ro/data/MZXE-alarm.tpl
+++ b/src/selftest-ro/data/MZXE-alarm.tpl
@@ -1,0 +1,8 @@
+manufacturer   = Zettler
+part-number    = MZXE (alarm)
+type           = fire-detector
+normal-state   = open
+gpx-direction  = GPI
+power-source   = internal
+alarm-severity = CRITICAL
+alarm-message  = Fire detected (alarm) in $location, initiating fire suppression activation countdown

--- a/src/selftest-ro/data/MZXE-prealarm.tpl
+++ b/src/selftest-ro/data/MZXE-prealarm.tpl
@@ -1,0 +1,8 @@
+manufacturer   = Zettler
+part-number    = MZXE (pre-alarm)
+type           = fire-detector
+normal-state   = open
+gpx-direction  = GPI
+power-source   = internal
+alarm-severity = WARNING
+alarm-message  = Fire detected (pre-alarm)


### PR DESCRIPTION
Solution: Add the needed description

Note: this PR will be completed with new rules in fty-alert-engine

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>