### PR TITLE
Problem: normal-state are mispelled for MZXE

### DIFF
--- a/src/selftest-ro/data/MZXE-alarm.tpl
+++ b/src/selftest-ro/data/MZXE-alarm.tpl
@@ -1,7 +1,7 @@
 manufacturer   = Zettler
 part-number    = MZXE (alarm)
 type           = fire-detector
-normal-state   = open
+normal-state   = opened
 gpx-direction  = GPI
 power-source   = internal
 alarm-severity = CRITICAL

--- a/src/selftest-ro/data/MZXE-prealarm.tpl
+++ b/src/selftest-ro/data/MZXE-prealarm.tpl
@@ -1,7 +1,7 @@
 manufacturer   = Zettler
 part-number    = MZXE (pre-alarm)
 type           = fire-detector
-normal-state   = open
+normal-state   = opened
 gpx-direction  = GPI
 power-source   = internal
 alarm-severity = WARNING


### PR DESCRIPTION
Solution: Use the right values ("opened" / "closed")

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>